### PR TITLE
Update rest-client version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ gemspec
 gem "fakeweb"
 gem "rspec", '2.8.0'
 gem "json", ">= 1.4.6"
-gem "rest-client", "1.6.1", :require => "restclient"
+gem "rest-client", ">= 1.6.7", :require => "restclient"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    google_url_shortener (0.0.5)
+    google_url_shortener (0.0.7)
       json (>= 1.4.6)
-      rest-client (= 1.6.1)
+      rest-client (>= 1.6.7)
       trollop (= 1.16.2)
 
 GEM
@@ -12,8 +12,8 @@ GEM
     diff-lcs (1.1.3)
     fakeweb (1.3.0)
     json (1.6.5)
-    mime-types (1.17.2)
-    rest-client (1.6.1)
+    mime-types (1.19)
+    rest-client (1.6.7)
       mime-types (>= 1.16)
     rspec (2.8.0)
       rspec-core (~> 2.8.0)
@@ -33,5 +33,5 @@ DEPENDENCIES
   fakeweb
   google_url_shortener!
   json (>= 1.4.6)
-  rest-client (= 1.6.1)
-  rspec
+  rest-client (>= 1.6.7)
+  rspec (= 2.8.0)

--- a/google_url_shortener.gemspec
+++ b/google_url_shortener.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project = "google_url_shortener"
   s.add_dependency "json", ">= 1.4.6"
-  s.add_dependency "rest-client", "1.6.1"
+  s.add_dependency "rest-client", ">= 1.6.7"
   s.add_dependency 'trollop', '1.16.2'
   s.add_development_dependency "bundler", ">= 1.0.0"
   s.add_development_dependency "rspec", "2.8.0"


### PR DESCRIPTION
Hi, thanks again for this awesome gem, I've updated the rest-client gem from 1.6.1 to 1.6.7, because it is incompatible with the last version of paypal-express, which I'm using :-)

```
Bundler could not find compatible versions for gem "rest-client":
  In Gemfile:
    google_url_shortener (~> 0.0.6) ruby depends on
      rest-client (= 1.6.1) ruby

    paypal-express (~> 0.4.7) ruby depends on
      rest-client (1.6.7)
```

I ran all tests and everything is working fine.
