### PR TITLE
Fix for API key - ensure it is in the URL

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    google_url_shortener (0.0.7)
+    google_url_shortener (0.0.8)
       json (>= 1.4.6)
       rest-client (>= 1.6.7)
       trollop (= 1.16.2)

--- a/lib/google/url_shortener/request.rb
+++ b/lib/google/url_shortener/request.rb
@@ -5,12 +5,12 @@ module Google
       REQUEST_HEADERS = { :content_type => :json, :accept => :json }
 
       def post(params={})
-        response = RestClient.post(BASE_URL, format_post_params(params), REQUEST_HEADERS)
+        response = RestClient.post(format_url_with_api_key, format_post_params(params), REQUEST_HEADERS)
         parse(response)
       end
 
       def get(params={})
-        full_url = [BASE_URL, "?", format_get_params(params)].join
+        full_url = [format_url_with_api_key, "&", format_get_params(params)].join
         response = RestClient.get(full_url)
         parse(response)
       end
@@ -18,6 +18,10 @@ module Google
       private
       def parse(response)
         JSON.parse(response)
+      end
+
+      def format_url_with_api_key()
+        [BASE_URL, "?key=", self.class.api_key].join
       end
 
       def format_post_params(params={})

--- a/lib/google/url_shortener/url.rb
+++ b/lib/google/url_shortener/url.rb
@@ -40,8 +40,7 @@ module Google
       end
       
       def params_for_request(params={})
-        base_params = { :key => self.class.api_key }
-        base_params.merge!(params)
+        base_params = params
       end
       
       def validate(key, hash={})

--- a/spec/lib/google/analytics_spec.rb
+++ b/spec/lib/google/analytics_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 module Google
   module UrlShortener
     describe Analytics do

--- a/spec/lib/google/base_spec.rb
+++ b/spec/lib/google/base_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 module Google
   module UrlShortener
     describe Base do

--- a/spec/lib/google/url_spec.rb
+++ b/spec/lib/google/url_spec.rb
@@ -1,9 +1,11 @@
+require 'spec_helper'
+
 module Google
   module UrlShortener
     describe Url do
       
       it "should have the correct attributes after shortening a URL" do
-        stub_request(Google::UrlShortener::Request::BASE_URL, :method => :post, :fixture => "shorten")
+        stub_request(Google::UrlShortener::Request::BASE_URL + "?key=#{@key}", :method => :post, :fixture => "shorten")
         
         url = Google::UrlShortener::Url.new(:long_url => @long_url)
         url.shorten!

--- a/spec/lib/url_shortener_spec.rb
+++ b/spec/lib/url_shortener_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 module Google
   describe UrlShortener do
     


### PR DESCRIPTION
This fixes issue
https://github.com/joshnesbitt/google_url_shortener/issues/4 - where
the API key is ignored in the POST data unless it is a URL parameter