### PR TITLE
Allow config option to raise exceptions if request fails.

### DIFF
--- a/google_url_shortener.gemspec
+++ b/google_url_shortener.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "bundler", ">= 1.0.0"
   s.add_development_dependency "rspec", "2.8.0"
+  s.add_development_dependency "rspec-mocks", "2.8.0"
   s.add_development_dependency "fakeweb"
 
   s.files        = `git ls-files`.split("\n")

--- a/lib/google/url_shortener/base.rb
+++ b/lib/google/url_shortener/base.rb
@@ -2,6 +2,7 @@ module Google
   module UrlShortener
     class Base
       class << self
+        @@raise_exceptions = false
         
         def log=(logger)
           RestClient.log = logger
@@ -17,6 +18,14 @@ module Google
           rescue NameError
             raise MissingApiKey, "No API key has been set!"
           end
+        end
+
+        def raise_exceptions=(bool)
+          @@raise_exceptions = !!bool
+        end
+
+        def raise_exceptions
+          @@raise_exceptions
         end
       end
     end

--- a/lib/google/url_shortener/request.rb
+++ b/lib/google/url_shortener/request.rb
@@ -8,7 +8,11 @@ module Google
         response = RestClient.post(format_url, format_post_params(params), REQUEST_HEADERS)
         parse(response)
       rescue => e
-        puts e.inspect
+        if self.class.raise_exceptions
+          raise e
+        else
+          puts e.inspect
+        end
       end
 
       def get(params={})
@@ -16,7 +20,11 @@ module Google
         response = RestClient.get(full_url)
         parse(response)
       rescue => e
-        puts e.inspect
+        if self.class.raise_exceptions
+          raise e
+        else
+          puts e.inspect
+        end
       end
 
     private

--- a/spec/lib/google/url_spec.rb
+++ b/spec/lib/google/url_spec.rb
@@ -26,6 +26,24 @@ module Google
         url.created_at.month.should == 01
         url.created_at.day.should   == 11
       end
+
+      it "should permit exceptions if raise_exceptions is true" do
+        RestClient.stub(:post) { raise RestClient::Request::RequestFailed }
+        prev_val = Base.raise_exceptions
+        Base.raise_exceptions = true
+
+        url = Google::UrlShortener::Url.new(:long_url => @long_url)
+        expect { url.shorten! }.to raise_error(RestClient::Request::RequestFailed)
+
+        Base.raise_exceptions = prev_val
+      end
+
+      it "should not raise exceptions if raise_exceptions is false" do
+        RestClient.stub(:post) { raise RestClient::Request::RequestFailed }
+
+        url = Google::UrlShortener::Url.new(:long_url => @long_url)
+        expect { url.shorten! }.to_not raise_error(RestClient::Request::RequestFailed)
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require 'fakeweb'
 include FakewebHelper
 
 RSpec.configure do |config|
+  config.mock_framework = :rspec
 
   config.before(:all) do
     Google::UrlShortener::Base.api_key = "TESTKEY"


### PR DESCRIPTION
@joshnesbitt not sure if you're interested in this change, but it was something we needed (e.g. Google returns HTTP 400 errors for t.co and possibly other domains, which we want to catch and log), so I thought I'd open this PR. Feel free to close/ignore. 

HTTP exceptions raised by rest-client are probably best handled by the application using this gem (unless it's being used from commandline).

Also, by effectively returning nil (result of `puts e.inspect`) this will cause a `NoMethodError` anyway in `Url#encode!` and `decode!` methods that expect `response` to be non-nil.

The new option defaults to false for backwards compatibility.

Also added rspec-mocks for testing this code.
